### PR TITLE
Update revenue labels

### DIFF
--- a/src/components/AttendanceSummary.tsx
+++ b/src/components/AttendanceSummary.tsx
@@ -122,7 +122,7 @@ const AttendanceSummary = ({ currentWeek }: AttendanceSummaryProps) => {
             <PoundSterling className="w-6 h-6 text-amber-600" />
             <div>
               <div className="text-2xl font-bold text-amber-700">£{totalRevenue.toFixed(2)}</div>
-              <div className="text-sm text-amber-600">Total Revenue</div>
+              <div className="text-sm text-amber-600">Total Income</div>
             </div>
           </div>
         </Card>

--- a/src/components/OrdersList.tsx
+++ b/src/components/OrdersList.tsx
@@ -65,7 +65,7 @@ const OrdersList = ({ currentWeek }: OrdersListProps) => {
         <Card className="p-4 bg-gradient-to-br from-amber-50 to-amber-100 border-amber-200">
           <div className="text-center">
             <div className="text-2xl font-bold text-amber-700">£{totalRevenue.toFixed(2)}</div>
-            <div className="text-sm text-amber-600">Total Revenue</div>
+            <div className="text-sm text-amber-600">Total Income</div>
           </div>
         </Card>
         <Card className="p-4 bg-gradient-to-br from-blue-50 to-blue-100 border-blue-200">


### PR DESCRIPTION
## Summary
- rename "Total Revenue" label to "Total Income"

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, no-require-imports)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68461263b77c8323a377f4a7a1aa1e9b