### PR TITLE
Add ability to edit existing orders

### DIFF
--- a/src/components/EditOrderForm.tsx
+++ b/src/components/EditOrderForm.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import CustomerInfoFields from "@/components/order/CustomerInfoFields";
+import MealSelectionField from "@/components/order/MealSelectionField";
+import SubItemsField from "@/components/order/SubItemsField";
+import DessertDrinkFields from "@/components/order/DessertDrinkFields";
+import SpecialRequestField from "@/components/order/SpecialRequestField";
+import { toast } from "@/hooks/use-toast";
+import { useOrders, useDessertInventory, useMealOptions, useSubItemOptions, Order } from "@/hooks/useSupabaseData";
+import { OrderFormData, getInitialFormData, validateOrderForm } from "@/utils/orderUtils";
+
+interface EditOrderFormProps {
+  order: Order;
+  onClose: () => void;
+}
+
+const EditOrderForm = ({ order, onClose }: EditOrderFormProps) => {
+  const { updateOrder } = useOrders();
+  const { desserts } = useDessertInventory();
+  const { mealOptions } = useMealOptions();
+  const { subItemOptions } = useSubItemOptions();
+
+  const [formData, setFormData] = useState<OrderFormData>(getInitialFormData());
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    setFormData({
+      customerName: order.customer_name,
+      mealChoice: order.meal_choice,
+      subItems: order.sub_items,
+      dessert: order.dessert || "",
+      drink: order.drink || "",
+      specialRequest: order.special_request || "",
+      tableNumber: order.table_number || "",
+      paidAmount: order.paid_amount ? order.paid_amount.toString() : "",
+      payItForwardAmount: order.pay_it_forward_amount ? order.pay_it_forward_amount.toString() : "",
+    });
+  }, [order]);
+
+  const handleFormUpdate = (update: Partial<OrderFormData>) => {
+    setFormData(prev => ({ ...prev, ...update }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!validateOrderForm(formData)) return;
+    setIsSubmitting(true);
+    try {
+      await updateOrder(order.id, {
+        customer_name: formData.customerName,
+        meal_choice: formData.mealChoice,
+        sub_items: formData.subItems,
+        dessert: formData.dessert || null,
+        drink: formData.drink || null,
+        special_request: formData.specialRequest || null,
+        table_number: formData.tableNumber || null,
+      });
+      toast({
+        title: "Order Updated",
+        description: `Meal updated for ${formData.customerName}.`,
+      });
+      onClose();
+    } catch (error) {
+      console.error("Error updating order:", error);
+      toast({
+        title: "Error",
+        description: "Failed to update order. Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const availableDesserts = desserts.filter(d => d.active && d.remaining_stock > 0);
+  const activeMealOptions = mealOptions.filter(m => m.active).map(m => m.name);
+  const activeSubItemOptions = subItemOptions.filter(s => s.active).map(s => s.name);
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <CustomerInfoFields formData={formData} onFormChange={handleFormUpdate} />
+      <MealSelectionField formData={formData} onFormChange={handleFormUpdate} mealOptions={activeMealOptions} />
+      <SubItemsField formData={formData} onFormChange={handleFormUpdate} subItemOptions={activeSubItemOptions} />
+      <DessertDrinkFields formData={formData} onFormChange={handleFormUpdate} availableDesserts={availableDesserts} />
+      <SpecialRequestField formData={formData} onFormChange={handleFormUpdate} />
+      <Button type="submit" disabled={isSubmitting} className="w-full">
+        {isSubmitting ? "Saving..." : "Save Changes"}
+      </Button>
+    </form>
+  );
+};
+
+export default EditOrderForm;

--- a/src/components/OrdersList.tsx
+++ b/src/components/OrdersList.tsx
@@ -7,6 +7,7 @@ import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Search, Filter } from "lucide-react";
+import EditOrderForm from "./EditOrderForm";
 import { useOrders, Order } from "@/hooks/useSupabaseData";
 import { toast } from "@/hooks/use-toast";
 
@@ -21,6 +22,8 @@ const OrdersList = ({ currentWeek }: OrdersListProps) => {
   const [selectedOrder, setSelectedOrder] = useState<Order | null>(null);
   const [paidAmount, setPaidAmount] = useState("");
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [orderToEdit, setOrderToEdit] = useState<Order | null>(null);
 
   const currentWeekOrders = orders.filter(order => order.week === currentWeek);
   
@@ -174,8 +177,19 @@ const OrdersList = ({ currentWeek }: OrdersListProps) => {
                   )}
                 </div>
                 
-                <div className="text-xs text-gray-500 md:text-right">
-                  {new Date(order.created_at).toLocaleString()}
+                <div className="text-xs text-gray-500 md:text-right space-y-1">
+                  <div>{new Date(order.created_at).toLocaleString()}</div>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setOrderToEdit(order);
+                      setEditDialogOpen(true);
+                    }}
+                  >
+                    Edit
+                  </Button>
                 </div>
               </div>
             </Card>
@@ -219,6 +233,22 @@ const OrdersList = ({ currentWeek }: OrdersListProps) => {
               Save
             </Button>
           </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <Dialog open={editDialogOpen} onOpenChange={setEditDialogOpen}>
+        <DialogContent className="max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Edit Order</DialogTitle>
+          </DialogHeader>
+          {orderToEdit && (
+            <EditOrderForm
+              order={orderToEdit}
+              onClose={() => {
+                setEditDialogOpen(false);
+                setOrderToEdit(null);
+              }}
+            />
+          )}
         </DialogContent>
       </Dialog>
     </div>

--- a/src/components/order/SpecialRequestField.tsx
+++ b/src/components/order/SpecialRequestField.tsx
@@ -1,0 +1,26 @@
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { OrderFormData } from "@/utils/orderUtils";
+
+interface SpecialRequestFieldProps {
+  formData: OrderFormData;
+  onFormChange: (update: Partial<OrderFormData>) => void;
+}
+
+const SpecialRequestField = ({ formData, onFormChange }: SpecialRequestFieldProps) => {
+  return (
+    <div className="space-y-2">
+      <Label htmlFor="specialRequest">Special Requests</Label>
+      <Textarea
+        id="specialRequest"
+        value={formData.specialRequest}
+        onChange={(e) => onFormChange({ specialRequest: e.target.value })}
+        placeholder="Any special dietary requirements or requests..."
+        className="border-green-200 focus:border-green-400"
+        rows={3}
+      />
+    </div>
+  );
+};
+
+export default SpecialRequestField;


### PR DESCRIPTION
## Summary
- allow orders to be edited via new `EditOrderForm`
- add a `SpecialRequestField` component to edit special requests separately
- update `OrdersList` to include Edit action and dialog

## Testing
- `npm run lint` *(fails: several existing lint errors)*
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_68461560ea388323ad88b167a9a109b9