### PR TITLE
Add print view for meal orders

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@
 import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-dom";
 import Index from "./pages/Index";
 import PublicOrderPage from "./PublicOrderPage";
+import PrintOrders from "./pages/PrintOrders";
 
 function App() {
   return (
@@ -10,6 +11,7 @@ function App() {
         <Route path="/" element={<Index />} />
         <Route path="/admin" element={<Navigate to="/" replace />} />
         <Route path="/public-order" element={<PublicOrderPage />} />
+        <Route path="/print-orders" element={<PrintOrders />} />
       </Routes>
     </Router>
   );

--- a/src/components/OrdersList.tsx
+++ b/src/components/OrdersList.tsx
@@ -6,7 +6,8 @@ import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Search, Filter } from "lucide-react";
+import { Search, Filter, Printer } from "lucide-react";
+import { Link } from "react-router-dom";
 import EditOrderForm from "./EditOrderForm";
 import { useOrders, Order } from "@/hooks/useSupabaseData";
 import { toast } from "@/hooks/use-toast";
@@ -56,11 +57,19 @@ const OrdersList = ({ currentWeek }: OrdersListProps) => {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center space-x-3 mb-6">
-        <div className="w-6 h-6 bg-green-600 rounded flex items-center justify-center">
-          <Search className="w-4 h-4 text-white" />
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center space-x-3">
+          <div className="w-6 h-6 bg-green-600 rounded flex items-center justify-center">
+            <Search className="w-4 h-4 text-white" />
+          </div>
+          <h2 className="text-2xl font-bold text-gray-900">Orders This Week</h2>
         </div>
-        <h2 className="text-2xl font-bold text-gray-900">Orders This Week</h2>
+        <Link to="/print-orders">
+          <Button size="sm" variant="outline" className="space-x-2">
+            <Printer className="w-4 h-4" />
+            <span>Print</span>
+          </Button>
+        </Link>
       </div>
 
       {/* Summary Cards */}

--- a/src/pages/PrintOrders.tsx
+++ b/src/pages/PrintOrders.tsx
@@ -1,0 +1,85 @@
+import { useMemo } from "react";
+import { useOrders } from "@/hooks/useSupabaseData";
+import { getCurrentWeek, formatWeekDisplay } from "@/utils/weekUtils";
+import { Button } from "@/components/ui/button";
+import { Printer } from "lucide-react";
+
+const PrintOrders = () => {
+  const { orders, loading } = useOrders();
+  const currentWeek = getCurrentWeek();
+
+  const grouped = useMemo(() => {
+    const weekOrders = orders.filter(o => o.week === currentWeek);
+    weekOrders.sort((a, b) => {
+      const aNum = a.table_number ? parseInt(a.table_number) : Infinity;
+      const bNum = b.table_number ? parseInt(b.table_number) : Infinity;
+      return aNum - bNum;
+    });
+    const groups: Record<string, typeof weekOrders> = {};
+    weekOrders.forEach(o => {
+      const key = o.table_number || "No Table";
+      if (!groups[key]) groups[key] = [];
+      groups[key].push(o);
+    });
+    return groups;
+  }, [orders, currentWeek]);
+
+  if (loading) {
+    return <div className="p-4">Loading...</div>;
+  }
+
+  const sortedTables = Object.keys(grouped).sort((a, b) => {
+    const aNum = a === "No Table" ? Infinity : parseInt(a);
+    const bNum = b === "No Table" ? Infinity : parseInt(b);
+    return aNum - bNum;
+  });
+
+  return (
+    <div className="p-4 space-y-6">
+      <div className="flex items-center justify-between print:hidden">
+        <h1 className="text-2xl font-bold">Meal Orders - Week of {formatWeekDisplay(currentWeek)}</h1>
+        <Button onClick={() => window.print()} variant="outline" className="space-x-2">
+          <Printer className="w-4 h-4" />
+          <span>Print</span>
+        </Button>
+      </div>
+
+      {sortedTables.map(table => (
+        <div key={table} className="space-y-2 break-inside-avoid">
+          <h2 className="font-semibold text-lg">{table === "No Table" ? "No Table" : `Table ${table}`}</h2>
+          <table className="w-full border border-gray-300 text-sm">
+            <thead className="bg-gray-100">
+              <tr>
+                <th className="border p-2 text-left">#</th>
+                <th className="border p-2 text-left">Customer</th>
+                <th className="border p-2 text-left">Meal</th>
+                <th className="border p-2 text-left">Details</th>
+              </tr>
+            </thead>
+            <tbody>
+              {grouped[table].map((o, idx) => (
+                <tr key={o.id} className="break-inside-avoid">
+                  <td className="border p-2 align-top">{idx + 1}</td>
+                  <td className="border p-2 align-top">{o.customer_name}</td>
+                  <td className="border p-2 align-top">{o.meal_choice}</td>
+                  <td className="border p-2 align-top">
+                    {[
+                      ...o.sub_items,
+                      o.dessert ? `Dessert: ${o.dessert}` : null,
+                      o.drink ? `Drink: ${o.drink}` : null,
+                      o.special_request ? `Special: ${o.special_request}` : null,
+                    ]
+                      .filter(Boolean)
+                      .join(", ")}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default PrintOrders;


### PR DESCRIPTION
## Summary
- add a printable orders page
- link the page from the admin order list
- expose the new page via router

## Testing
- `npm run lint` *(fails: 14 problems)*

------
https://chatgpt.com/codex/tasks/task_e_684688cef44083239957f6d2732df5e7