### PR TITLE
Remove pay it forward from public orders

### DIFF
--- a/src/components/OrderForm.tsx
+++ b/src/components/OrderForm.tsx
@@ -132,10 +132,12 @@ const OrderForm = ({ currentWeek, mode = "admin" }: OrderFormProps) => {
         availableDesserts={availableDesserts} 
       />
 
-      <PayItForwardField 
-        formData={formData} 
-        onFormChange={handleFormUpdate} 
-      />
+      {mode !== "public" && (
+        <PayItForwardField
+          formData={formData}
+          onFormChange={handleFormUpdate}
+        />
+      )}
 
       {mode === "admin" && (
         <PaymentRequestFields 


### PR DESCRIPTION
## Summary
- only render the Pay It Forward field when not on the public order page

## Testing
- `npm run lint` *(fails: Unexpected any and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68468ef38fb08323b3ad7e47d57a251f