### PR TITLE
Fix editing not reflecting updated meal

### DIFF
--- a/src/components/EditOrderForm.tsx
+++ b/src/components/EditOrderForm.tsx
@@ -6,16 +6,16 @@ import SubItemsField from "@/components/order/SubItemsField";
 import DessertDrinkFields from "@/components/order/DessertDrinkFields";
 import SpecialRequestField from "@/components/order/SpecialRequestField";
 import { toast } from "@/hooks/use-toast";
-import { useOrders, useDessertInventory, useMealOptions, useSubItemOptions, Order } from "@/hooks/useSupabaseData";
+import { useDessertInventory, useMealOptions, useSubItemOptions, Order } from "@/hooks/useSupabaseData";
 import { OrderFormData, validateOrderForm } from "@/utils/orderUtils";
 
 interface EditOrderFormProps {
   order: Order;
   onClose: () => void;
+  updateOrder: (id: string, updates: Partial<Order>) => Promise<void>;
 }
 
-const EditOrderForm = ({ order, onClose }: EditOrderFormProps) => {
-  const { updateOrder } = useOrders();
+const EditOrderForm = ({ order, onClose, updateOrder }: EditOrderFormProps) => {
   const { desserts } = useDessertInventory();
   const { mealOptions } = useMealOptions();
   const { subItemOptions } = useSubItemOptions();

--- a/src/components/OrdersList.tsx
+++ b/src/components/OrdersList.tsx
@@ -252,6 +252,7 @@ const OrdersList = ({ currentWeek }: OrdersListProps) => {
           {orderToEdit && (
             <EditOrderForm
               order={orderToEdit}
+              updateOrder={updateOrder}
               onClose={() => {
                 setEditDialogOpen(false);
                 setOrderToEdit(null);


### PR DESCRIPTION
## Summary
- pass `updateOrder` from OrdersList into EditOrderForm
- remove separate useOrders instance in EditOrderForm

This ensures changes are reflected immediately after editing a meal.

## Testing
- `npm run lint` *(fails: Unexpected any and other pre-existing warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846c6e88f6c8323ac926c719f014c78