### PR TITLE
Add Supabase auth and admin login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,32 @@
 
-import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-dom";
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import PublicOrderPage from "./PublicOrderPage";
 import PrintOrders from "./pages/PrintOrders";
+import Login from "./pages/Login";
+import RequireAuth from "@/components/RequireAuth";
+import { AuthProvider } from "@/hooks/useAuth";
 
 function App() {
   return (
-    <Router>
-      <Routes>
-        <Route path="/" element={<Index />} />
-        <Route path="/admin" element={<Navigate to="/" replace />} />
-        <Route path="/public-order" element={<PublicOrderPage />} />
-        <Route path="/print-orders" element={<PrintOrders />} />
-      </Routes>
-    </Router>
+    <AuthProvider>
+      <Router>
+        <Routes>
+          <Route path="/" element={<Index />} />
+          <Route
+            path="/admin"
+            element={
+              <RequireAuth>
+                <Index initialRole="admin" />
+              </RequireAuth>
+            }
+          />
+          <Route path="/login" element={<Login />} />
+          <Route path="/public-order" element={<PublicOrderPage />} />
+          <Route path="/print-orders" element={<PrintOrders />} />
+        </Routes>
+      </Router>
+    </AuthProvider>
   );
 }
 

--- a/src/components/RequireAuth.tsx
+++ b/src/components/RequireAuth.tsx
@@ -1,0 +1,21 @@
+import { Navigate, useLocation } from "react-router-dom";
+import { useAuth } from "@/hooks/useAuth";
+
+interface Props {
+  children: JSX.Element;
+}
+
+const RequireAuth = ({ children }: Props) => {
+  const { user, loading } = useAuth();
+  const location = useLocation();
+
+  if (loading) return null;
+
+  if (!user) {
+    return <Navigate to="/login" state={{ from: location.pathname }} replace />;
+  }
+
+  return children;
+};
+
+export default RequireAuth;

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,0 +1,56 @@
+import { createContext, useContext, useEffect, useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import type { User } from "@supabase/supabase-js";
+
+interface AuthContextValue {
+  user: User | null;
+  loading: boolean;
+  signIn: (opts: { email: string; password: string }) => Promise<void>;
+  signOut: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const init = async () => {
+      const { data } = await supabase.auth.getSession();
+      setUser(data.session?.user ?? null);
+      setLoading(false);
+    };
+    init();
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+    });
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  const signIn = async ({ email, password }: { email: string; password: string }) => {
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) throw error;
+  };
+
+  const signOut = async () => {
+    const { error } = await supabase.auth.signOut();
+    if (error) throw error;
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, loading, signIn, signOut }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
+  return ctx;
+};

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -12,10 +13,23 @@ import MenuManager from "@/components/MenuManager";
 import PayItForwardManager from "@/components/PayItForwardManager";
 import PayItForwardBalance from "@/components/PayItForwardBalance";
 import { getCurrentWeek, formatWeekDisplay } from "@/utils/weekUtils";
+import { useAuth } from "@/hooks/useAuth";
 
-const Index = () => {
-  const [userRole, setUserRole] = useState<"volunteer" | "admin">("volunteer");
+interface Props {
+  initialRole?: "volunteer" | "admin";
+}
+
+const Index = ({ initialRole = "volunteer" }: Props) => {
+  const [userRole, setUserRole] = useState<"volunteer" | "admin">(initialRole);
   const [currentWeek] = useState(() => getCurrentWeek());
+  const { user, signOut } = useAuth();
+  const navigate = useNavigate();
+
+  const handleSignOut = async () => {
+    await signOut();
+    setUserRole("volunteer");
+    navigate("/");
+  };
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-50 to-amber-50">
@@ -49,6 +63,11 @@ const Index = () => {
               >
                 Admin
               </Button>
+              {user && (
+                <Button variant="outline" size="sm" onClick={handleSignOut} className="text-xs">
+                  Sign Out
+                </Button>
+              )}
             </div>
           </div>
         </div>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useAuth } from "@/hooks/useAuth";
+
+const Login = () => {
+  const { signIn } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const from = (location.state as { from?: string })?.from || "/admin";
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    try {
+      await signIn({ email, password });
+      navigate(from, { replace: true });
+    } catch {
+      setError("Invalid login credentials");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gradient-to-br from-green-50 to-amber-50">
+      <Card className="p-6 w-80 space-y-4">
+        <h1 className="text-xl font-bold text-center">Admin Login</h1>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="password">Password</Label>
+            <Input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
+          {error && <div className="text-red-500 text-sm">{error}</div>}
+          <Button type="submit" className="w-full" disabled={loading}>
+            {loading ? "Signing in..." : "Sign In"}
+          </Button>
+        </form>
+      </Card>
+    </div>
+  );
+};
+
+export default Login;


### PR DESCRIPTION
## Summary
- implement an `AuthProvider` hook to track Supabase session
- add a login page and `RequireAuth` wrapper
- protect `/admin` route and allow sign out from header

## Testing
- `bun x eslint .` *(fails: `@typescript-eslint/no-empty-object-type` and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6846ddb0ce348323b3fd9271f117cfa5