### PR TITLE
Add confirmation message after public order submission

### DIFF
--- a/src/PublicOrderPage.tsx
+++ b/src/PublicOrderPage.tsx
@@ -1,9 +1,15 @@
 
-import React from "react";
+import React, { useState } from "react";
 import OrderForm from "./components/OrderForm";
 import { getCurrentWeek } from "./utils/weekUtils";
 
 const PublicOrderPage = () => {
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleSuccess = () => {
+    setSubmitted(true);
+  };
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-50 to-amber-50">
       <div className="max-w-lg mx-auto px-4 py-8">
@@ -12,7 +18,12 @@ const PublicOrderPage = () => {
             <h1 className="text-2xl font-bold text-gray-900 mb-2">Order Your Lunch</h1>
             <p className="text-gray-600">Place your order for today's lunch service</p>
           </div>
-          <OrderForm currentWeek={getCurrentWeek()} mode="public" />
+          {submitted && (
+            <div className="mb-4 p-3 rounded-md bg-green-50 text-green-800 border border-green-200 text-center">
+              Order received! Thank you.
+            </div>
+          )}
+          <OrderForm currentWeek={getCurrentWeek()} mode="public" onSuccess={handleSuccess} />
         </div>
       </div>
     </div>

--- a/src/components/OrderForm.tsx
+++ b/src/components/OrderForm.tsx
@@ -21,9 +21,10 @@ import {
 interface OrderFormProps {
   currentWeek: string;
   mode?: "admin" | "public";
+  onSuccess?: () => void;
 }
 
-const OrderForm = ({ currentWeek, mode = "admin" }: OrderFormProps) => {
+const OrderForm = ({ currentWeek, mode = "admin", onSuccess }: OrderFormProps) => {
   const { addOrder } = useOrders();
   const { desserts, updateDessert } = useDessertInventory();
   const { mealOptions } = useMealOptions();
@@ -90,6 +91,9 @@ const OrderForm = ({ currentWeek, mode = "admin" }: OrderFormProps) => {
       });
 
       setFormData(getInitialFormData());
+      if (onSuccess) {
+        onSuccess();
+      }
     } catch (error) {
       console.error('Error submitting order:', error);
       toast({


### PR DESCRIPTION
## Summary
- notify parent component of successful order submission
- show confirmation message on public order page

## Testing
- `npm run lint` *(fails: Unexpected any, no-empty-object-type, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684759fe32a88323a702ff9cab27cd68