### PR TITLE
Remove drink field from public order page

### DIFF
--- a/src/components/OrderForm.tsx
+++ b/src/components/OrderForm.tsx
@@ -130,10 +130,11 @@ const OrderForm = ({ currentWeek, mode = "admin", onSuccess }: OrderFormProps) =
         subItemOptions={activeSubItemOptions} 
       />
 
-      <DessertDrinkFields 
-        formData={formData} 
-        onFormChange={handleFormUpdate} 
-        availableDesserts={availableDesserts} 
+      <DessertDrinkFields
+        formData={formData}
+        onFormChange={handleFormUpdate}
+        availableDesserts={availableDesserts}
+        showDrink={mode !== "public"}
       />
 
       {mode !== "public" && (

--- a/src/components/order/DessertDrinkFields.tsx
+++ b/src/components/order/DessertDrinkFields.tsx
@@ -8,9 +8,10 @@ interface DessertDrinkFieldsProps {
   formData: OrderFormData;
   onFormChange: (update: Partial<OrderFormData>) => void;
   availableDesserts: Array<{ name: string; remaining_stock: number }>;
+  showDrink?: boolean;
 }
 
-const DessertDrinkFields = ({ formData, onFormChange, availableDesserts }: DessertDrinkFieldsProps) => {
+const DessertDrinkFields = ({ formData, onFormChange, availableDesserts, showDrink = true }: DessertDrinkFieldsProps) => {
   const handleDessertChange = (value: string) => {
     // Convert "none" back to empty string for the form data
     const dessertValue = value === "none" ? "" : value;
@@ -21,8 +22,8 @@ const DessertDrinkFields = ({ formData, onFormChange, availableDesserts }: Desse
     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
       <div className="space-y-2">
         <Label htmlFor="dessert">Dessert (Optional)</Label>
-        <Select 
-          value={formData.dessert || "none"} 
+        <Select
+          value={formData.dessert || "none"}
           onValueChange={handleDessertChange}
         >
           <SelectTrigger className="border-green-200 focus:border-green-400">
@@ -38,17 +39,18 @@ const DessertDrinkFields = ({ formData, onFormChange, availableDesserts }: Desse
           </SelectContent>
         </Select>
       </div>
-
-      <div className="space-y-2">
-        <Label htmlFor="drink">Drink (Optional)</Label>
-        <Input
-          id="drink"
-          value={formData.drink}
-          onChange={(e) => onFormChange({ drink: e.target.value })}
-          placeholder="e.g., Tea, Coffee, Water"
-          className="border-green-200 focus:border-green-400"
-        />
-      </div>
+      {showDrink && (
+        <div className="space-y-2">
+          <Label htmlFor="drink">Drink (Optional)</Label>
+          <Input
+            id="drink"
+            value={formData.drink}
+            onChange={(e) => onFormChange({ drink: e.target.value })}
+            placeholder="e.g., Tea, Coffee, Water"
+            className="border-green-200 focus:border-green-400"
+          />
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- hide drink field in DessertDrinkFields when `showDrink` prop is false
- pass `showDrink={mode !== "public"}` from OrderForm

## Testing
- `npm run lint` *(fails: errors in unrelated files)*
- `npx eslint src/components/order/DessertDrinkFields.tsx src/components/OrderForm.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68475c2403548323ac6e69208f35e7ee