### PR TITLE
Allow viewing orders when logged out

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import Orders from "./pages/Orders";
 import PublicOrderPage from "./PublicOrderPage";
 import PrintOrders from "./pages/PrintOrders";
 import Login from "./pages/Login";
@@ -13,6 +14,7 @@ function App() {
       <Router>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/orders" element={<Orders />} />
           <Route
             path="/admin"
             element={

--- a/src/components/NavButtons.tsx
+++ b/src/components/NavButtons.tsx
@@ -1,0 +1,55 @@
+import { Button } from "@/components/ui/button";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "@/hooks/useAuth";
+
+interface Props {
+  active?: "volunteer" | "admin" | "orders";
+  onSignOut?: () => void;
+}
+
+const NavButtons = ({ active, onSignOut }: Props) => {
+  const { user, signOut } = useAuth();
+  const navigate = useNavigate();
+
+  const handleSignOut = async () => {
+    await signOut();
+    if (onSignOut) onSignOut();
+    navigate("/");
+  };
+
+  return (
+    <div className="flex items-center space-x-2">
+      <Button
+        variant={active === "volunteer" ? "default" : "outline"}
+        size="sm"
+        onClick={() => navigate("/")}
+        className="text-xs"
+      >
+        Volunteer
+      </Button>
+      <Button
+        variant={active === "orders" ? "default" : "outline"}
+        size="sm"
+        onClick={() => navigate("/orders")}
+        className="text-xs"
+      >
+        Orders
+      </Button>
+      <Button
+        variant={active === "admin" ? "default" : "outline"}
+        size="sm"
+        onClick={() => navigate("/admin")}
+        className="text-xs"
+      >
+        Admin
+      </Button>
+      {user && (
+        <Button variant="outline" size="sm" onClick={handleSignOut} className="text-xs">
+          Sign Out
+        </Button>
+      )}
+    </div>
+  );
+};
+
+export default NavButtons;

--- a/src/components/OrdersList.tsx
+++ b/src/components/OrdersList.tsx
@@ -14,9 +14,10 @@ import { toast } from "@/hooks/use-toast";
 
 interface OrdersListProps {
   currentWeek: string;
+  readOnly?: boolean;
 }
 
-const OrdersList = ({ currentWeek }: OrdersListProps) => {
+const OrdersList = ({ currentWeek, readOnly = false }: OrdersListProps) => {
   const { orders, loading, updateOrder } = useOrders();
   const [searchTerm, setSearchTerm] = useState("");
   const [filterTable, setFilterTable] = useState("all");
@@ -134,12 +135,18 @@ const OrdersList = ({ currentWeek }: OrdersListProps) => {
           filteredOrders.map((order) => (
             <Card
               key={order.id}
-              className="p-4 hover:shadow-md transition-shadow border-green-100 cursor-pointer"
-              onClick={() => {
-                setSelectedOrder(order);
-                setPaidAmount(order.paid_amount ? order.paid_amount.toString() : "");
-                setDialogOpen(true);
-              }}
+              className={
+                readOnly
+                  ? "p-4 border-green-100"
+                  : "p-4 hover:shadow-md transition-shadow border-green-100 cursor-pointer"
+              }
+              {...(!readOnly && {
+                onClick: () => {
+                  setSelectedOrder(order);
+                  setPaidAmount(order.paid_amount ? order.paid_amount.toString() : "");
+                  setDialogOpen(true);
+                },
+              })}
             >
               <div className="flex flex-col md:flex-row md:items-center justify-between space-y-3 md:space-y-0">
                 <div className="flex-1">
@@ -188,17 +195,19 @@ const OrdersList = ({ currentWeek }: OrdersListProps) => {
                 
                 <div className="text-xs text-gray-500 md:text-right space-y-1">
                   <div>{new Date(order.created_at).toLocaleString()}</div>
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setOrderToEdit(order);
-                      setEditDialogOpen(true);
-                    }}
-                  >
-                    Edit
-                  </Button>
+                  {!readOnly && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setOrderToEdit(order);
+                        setEditDialogOpen(true);
+                      }}
+                    >
+                      Edit
+                    </Button>
+                  )}
                 </div>
               </div>
             </Card>
@@ -206,61 +215,65 @@ const OrdersList = ({ currentWeek }: OrdersListProps) => {
         )}
       </div>
 
-      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Update Payment</DialogTitle>
-          </DialogHeader>
-          {selectedOrder && (
-            <div className="space-y-4">
-              <div className="font-medium">{selectedOrder.customer_name}</div>
-              <Input
-                type="number"
-                step="0.01"
-                value={paidAmount}
-                onChange={(e) => setPaidAmount(e.target.value)}
-                placeholder="Amount paid"
-              />
-            </div>
-          )}
-          <DialogFooter className="pt-4">
-            <Button
-              onClick={async () => {
-                if (selectedOrder) {
-                  await updateOrder(selectedOrder.id, {
-                    paid_amount: paidAmount ? parseFloat(paidAmount) : null,
-                  });
-                  toast({
-                    title: "Order Updated",
-                    description: `Payment details updated for ${selectedOrder.customer_name}.`,
-                  });
-                }
-                setDialogOpen(false);
-                setSelectedOrder(null);
-              }}
-            >
-              Save
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-      <Dialog open={editDialogOpen} onOpenChange={setEditDialogOpen}>
-        <DialogContent className="max-h-[90vh] overflow-y-auto">
-          <DialogHeader>
-            <DialogTitle>Edit Order</DialogTitle>
-          </DialogHeader>
-          {orderToEdit && (
-            <EditOrderForm
-              order={orderToEdit}
-              updateOrder={updateOrder}
-              onClose={() => {
-                setEditDialogOpen(false);
-                setOrderToEdit(null);
-              }}
-            />
-          )}
-        </DialogContent>
-      </Dialog>
+      {!readOnly && (
+        <>
+          <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Update Payment</DialogTitle>
+              </DialogHeader>
+              {selectedOrder && (
+                <div className="space-y-4">
+                  <div className="font-medium">{selectedOrder.customer_name}</div>
+                  <Input
+                    type="number"
+                    step="0.01"
+                    value={paidAmount}
+                    onChange={(e) => setPaidAmount(e.target.value)}
+                    placeholder="Amount paid"
+                  />
+                </div>
+              )}
+              <DialogFooter className="pt-4">
+                <Button
+                  onClick={async () => {
+                    if (selectedOrder) {
+                      await updateOrder(selectedOrder.id, {
+                        paid_amount: paidAmount ? parseFloat(paidAmount) : null,
+                      });
+                      toast({
+                        title: "Order Updated",
+                        description: `Payment details updated for ${selectedOrder.customer_name}.`,
+                      });
+                    }
+                    setDialogOpen(false);
+                    setSelectedOrder(null);
+                  }}
+                >
+                  Save
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+          <Dialog open={editDialogOpen} onOpenChange={setEditDialogOpen}>
+            <DialogContent className="max-h-[90vh] overflow-y-auto">
+              <DialogHeader>
+                <DialogTitle>Edit Order</DialogTitle>
+              </DialogHeader>
+              {orderToEdit && (
+                <EditOrderForm
+                  order={orderToEdit}
+                  updateOrder={updateOrder}
+                  onClose={() => {
+                    setEditDialogOpen(false);
+                    setOrderToEdit(null);
+                  }}
+                />
+              )}
+            </DialogContent>
+          </Dialog>
+        </>
+      )}
     </div>
   );
 };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,4 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Users, ClipboardList, Package, Calendar, Settings, UtensilsCrossed, Heart } from "lucide-react";
@@ -12,6 +10,7 @@ import AdminControls from "@/components/AdminControls";
 import MenuManager from "@/components/MenuManager";
 import PayItForwardManager from "@/components/PayItForwardManager";
 import PayItForwardBalance from "@/components/PayItForwardBalance";
+import NavButtons from "@/components/NavButtons";
 import { getCurrentWeek, formatWeekDisplay } from "@/utils/weekUtils";
 import { useAuth } from "@/hooks/useAuth";
 
@@ -22,14 +21,7 @@ interface Props {
 const Index = ({ initialRole = "volunteer" }: Props) => {
   const [userRole, setUserRole] = useState<"volunteer" | "admin">(initialRole);
   const [currentWeek] = useState(() => getCurrentWeek());
-  const { user, signOut } = useAuth();
-  const navigate = useNavigate();
-
-  const handleSignOut = async () => {
-    await signOut();
-    setUserRole("volunteer");
-    navigate("/");
-  };
+  const { user } = useAuth();
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-50 to-amber-50">
@@ -46,29 +38,7 @@ const Index = ({ initialRole = "volunteer" }: Props) => {
                 <p className="text-sm text-gray-600">Week of {formatWeekDisplay(currentWeek)}</p>
               </div>
             </div>
-            <div className="flex items-center space-x-2">
-              <Button
-                variant={userRole === "volunteer" ? "default" : "outline"}
-                size="sm"
-                onClick={() => navigate("/")}
-                className="text-xs"
-              >
-                Volunteer
-              </Button>
-              <Button
-                variant={userRole === "admin" ? "default" : "outline"}
-                size="sm"
-                onClick={() => navigate("/admin")}
-                className="text-xs"
-              >
-                Admin
-              </Button>
-              {user && (
-                <Button variant="outline" size="sm" onClick={handleSignOut} className="text-xs">
-                  Sign Out
-                </Button>
-              )}
-            </div>
+            <NavButtons active={userRole} onSignOut={() => setUserRole("volunteer")} />
           </div>
         </div>
       </div>

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+import OrdersList from "@/components/OrdersList";
+import NavButtons from "@/components/NavButtons";
+import { getCurrentWeek, formatWeekDisplay } from "@/utils/weekUtils";
+import { Users } from "lucide-react";
+
+const Orders = () => {
+  const [currentWeek] = useState(() => getCurrentWeek());
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-green-50 to-amber-50">
+      <div className="bg-white shadow-sm border-b border-green-100">
+        <div className="max-w-4xl mx-auto px-4 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-3">
+              <div className="w-10 h-10 bg-gradient-to-br from-green-600 to-green-700 rounded-lg flex items-center justify-center">
+                <Users className="w-6 h-6 text-white" />
+              </div>
+              <div>
+                <h1 className="text-xl font-bold text-gray-900">DMT Lunch Club App</h1>
+                <p className="text-sm text-gray-600">Week of {formatWeekDisplay(currentWeek)}</p>
+              </div>
+            </div>
+            <NavButtons active="orders" />
+          </div>
+        </div>
+      </div>
+
+      <div className="max-w-4xl mx-auto px-4 py-6">
+        <OrdersList currentWeek={currentWeek} readOnly />
+      </div>
+    </div>
+  );
+};
+
+export default Orders;


### PR DESCRIPTION
## Summary
- add `NavButtons` component with Orders navigation
- add read-only capability to `OrdersList`
- create public `Orders` page
- use `NavButtons` in Index page
- register new route for `/orders`

## Testing
- `npm run lint` *(fails: several lint errors in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_684760b8abc0832382d43214be01120c