### PR TITLE
Add Mark Paid button for readonly orders

### DIFF
--- a/src/components/OrdersList.tsx
+++ b/src/components/OrdersList.tsx
@@ -208,6 +208,21 @@ const OrdersList = ({ currentWeek, readOnly = false }: OrdersListProps) => {
                       Edit
                     </Button>
                   )}
+                  {readOnly && !order.paid_amount && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={async () => {
+                        await updateOrder(order.id, { paid_amount: 0 });
+                        toast({
+                          title: "Order Updated",
+                          description: `Marked ${order.customer_name}'s meal as paid.`,
+                        });
+                      }}
+                    >
+                      Mark Paid
+                    </Button>
+                  )}
                 </div>
               </div>
             </Card>


### PR DESCRIPTION
## Summary
- add a simple "Mark Paid" button in `OrdersList` when on the readonly orders page

## Testing
- `npm run lint` *(fails: Unexpected any / other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6848178173b48323a8a644ad4315ec28